### PR TITLE
Handle building up associations with EthnicChurchBuilder

### DIFF
--- a/app/controllers/ethnic_churches_controller.rb
+++ b/app/controllers/ethnic_churches_controller.rb
@@ -13,13 +13,7 @@ class EthnicChurchesController < ApplicationController
   end
 
   def create
-    @ethnic_church = EthnicChurch.new(ethnic_church_params)
-    languages = params[:language][:name]
-    @ethnic_church.languages = languages
-    @ethnic_church.country = Country.find_or_initialize_by(name: country_params[:name])
-    @ethnic_church.religious_background = ReligiousBackground.find_or_initialize_by(persuasion: religious_background_params[:persuasion])
-    @ethnic_church.build_address(address_params)
-    @ethnic_church.build_note(note_params)
+    @ethnic_church = EthnicChurchBuilder.instantiate(params)
 
     if @ethnic_church.save
       redirect_to ethnic_church_path(@ethnic_church), notice: 'Successfully added new Ethnic Church'
@@ -27,33 +21,5 @@ class EthnicChurchesController < ApplicationController
       flash.now.alert = @ethnic_church.errors.full_messages.join(', ')
       render 'new'
     end
-  end
-
-  private
-
-  def ethnic_church_params
-    params.require(:ethnic_church)
-      .permit(:name, :phone, :website, :pastors_name, :email)
-      .transform_values { |val| val if val.present? }
-  end
-
-  def language_params
-    params.require(:language).permit(:name)
-  end
-
-  def country_params
-    params.require(:country).permit(:name)
-  end
-
-  def religious_background_params
-    params.require(:religious_background).permit(:persuasion)
-  end
-
-  def note_params
-    params.require(:note).permit(:content)
-  end
-
-  def address_params
-    params.require(:address).permit(:street, :city, :zip)
   end
 end

--- a/app/controllers/ethnic_churches_controller.rb
+++ b/app/controllers/ethnic_churches_controller.rb
@@ -13,7 +13,14 @@ class EthnicChurchesController < ApplicationController
   end
 
   def create
-    @ethnic_church = EthnicChurchBuilder.instantiate(params)
+    @ethnic_church = EthnicChurchBuilder.instantiate(
+      ethnic_church: ethnic_church,
+      languages: languages,
+      country: country,
+      religious_background: religious_background,
+      address: address,
+      note: note
+    )
 
     if @ethnic_church.save
       redirect_to ethnic_church_path(@ethnic_church), notice: 'Successfully added new Ethnic Church'
@@ -21,5 +28,49 @@ class EthnicChurchesController < ApplicationController
       flash.now.alert = @ethnic_church.errors.full_messages.join(', ')
       render 'new'
     end
+  end
+
+  private
+
+  def ethnic_church
+    EthnicChurch.new(ethnic_church_params)
+  end
+
+  def languages
+    params[:language][:name].reject(&:blank?).map do |lang_name|
+      Language.find_or_initialize_by(name: lang_name)
+    end
+  end
+
+  def country
+    country = params[:country][:name]
+    Country.find_or_initialize_by(name: country)
+  end
+
+  def address
+    Address.new(address_params)
+  end
+
+  def note
+    Note.new(note_params)
+  end
+
+  def note_params
+    params.require(:note).permit(:content)
+  end
+
+  def religious_background
+    persuasion = params[:religious_background][:persuasion]
+    ReligiousBackground.find_or_initialize_by(persuasion: persuasion)
+  end
+
+  def ethnic_church_params
+    params.require(:ethnic_church)
+      .permit(:name, :phone, :website, :pastors_name, :email)
+      .transform_values { |val| val if val.present? }
+  end
+
+  def address_params
+    params.require(:address).permit(:street, :city, :zip)
   end
 end

--- a/app/models/ethnic_church.rb
+++ b/app/models/ethnic_church.rb
@@ -6,13 +6,4 @@ class EthnicChurch < ApplicationRecord
   belongs_to :religious_background
 
   validates :email, format: { with: Devise.email_regexp }, allow_nil: true
-
-  def languages=(names)
-    language_records = names.map do |language|
-      next if language.blank?
-      Language.find_or_initialize_by(name: language)
-    end.compact
-
-    super(language_records)
-  end
 end

--- a/app/models/ethnic_church_builder.rb
+++ b/app/models/ethnic_church_builder.rb
@@ -1,0 +1,49 @@
+class EthnicChurchBuilder
+  class << self
+    def instantiate(params)
+      @params = params
+
+      @ec = EthnicChurch.new(ethnic_church_params)
+
+      @ec.languages = languages
+      @ec.country = country
+      @ec.religious_background = religious_background
+      @ec.build_address(address_params)
+      @ec.build_note(note_params)
+
+      @ec
+    end
+
+    private
+
+    def languages
+      @params[:language][:name].reject(&:blank?).map do |lang_name|
+        Language.find_or_initialize_by(name: lang_name)
+      end
+    end
+
+    def country
+      country = @params[:country][:name]
+      Country.find_or_initialize_by(name: country)
+    end
+
+    def religious_background
+      persuasion = @params[:religious_background][:persuasion]
+      ReligiousBackground.find_or_initialize_by(persuasion: persuasion)
+    end
+
+    def ethnic_church_params
+      @params.require(:ethnic_church)
+        .permit(:name, :phone, :website, :pastors_name, :email)
+        .transform_values { |val| val if val.present? }
+    end
+
+    def note_params
+      @params.require(:note).permit(:content)
+    end
+
+    def address_params
+      @params.require(:address).permit(:street, :city, :zip)
+    end
+  end
+end

--- a/app/models/ethnic_church_builder.rb
+++ b/app/models/ethnic_church_builder.rb
@@ -1,49 +1,11 @@
 class EthnicChurchBuilder
-  class << self
-    def instantiate(params)
-      @params = params
-
-      @ec = EthnicChurch.new(ethnic_church_params)
-
-      @ec.languages = languages
-      @ec.country = country
-      @ec.religious_background = religious_background
-      @ec.build_address(address_params)
-      @ec.build_note(note_params)
-
-      @ec
-    end
-
-    private
-
-    def languages
-      @params[:language][:name].reject(&:blank?).map do |lang_name|
-        Language.find_or_initialize_by(name: lang_name)
-      end
-    end
-
-    def country
-      country = @params[:country][:name]
-      Country.find_or_initialize_by(name: country)
-    end
-
-    def religious_background
-      persuasion = @params[:religious_background][:persuasion]
-      ReligiousBackground.find_or_initialize_by(persuasion: persuasion)
-    end
-
-    def ethnic_church_params
-      @params.require(:ethnic_church)
-        .permit(:name, :phone, :website, :pastors_name, :email)
-        .transform_values { |val| val if val.present? }
-    end
-
-    def note_params
-      @params.require(:note).permit(:content)
-    end
-
-    def address_params
-      @params.require(:address).permit(:street, :city, :zip)
-    end
+  def self.instantiate(objects)
+    @ec = objects[:ethnic_church]
+    @ec.languages = objects[:languages]
+    @ec.country = objects[:country]
+    @ec.religious_background = objects[:religious_background]
+    @ec.address = objects[:address]
+    @ec.note = objects[:note]
+    @ec
   end
 end

--- a/test/models/ethnic_church_builder_test.rb
+++ b/test/models/ethnic_church_builder_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class EthnicChurchBuilderTest < ActiveSupport::TestCase
+  test 'EthnicChurchBuilder.instantiate' do
+    params = ActionController::Parameters.new({
+      ethnic_church: {
+        name: 'Foobar Korean Church',
+        phone: '123-456-7890',
+        website: 'https://example.com',
+        pastors_name: 'Peter Kim',
+        email: 'contact@example.com'
+      },
+      language: {
+        name: ['Korean', 'English']
+      },
+      country: {
+        name: 'Korea'
+      },
+      religious_background: {
+        persuasion: 'Protestant'
+      },
+      address: {
+        street: '1234 Foo St.',
+        city: 'Los Angeles',
+        zip: '90000'
+      },
+      note: {
+        content: 'Look! A note!'
+      }
+    })
+
+    ec = EthnicChurchBuilder.instantiate(params)
+
+    assert_equal ec.name, params[:ethnic_church][:name]
+    assert_equal ec.phone, params[:ethnic_church][:phone]
+    assert_equal ec.website, params[:ethnic_church][:website]
+    assert_equal ec.pastors_name, params[:ethnic_church][:pastors_name]
+    assert_equal ec.email, params[:ethnic_church][:email]
+
+    params[:language][:name].each do |lang_name|
+      assert_includes ec.languages.map(&:name), lang_name
+    end
+
+    assert_equal ec.country.name, params[:country][:name]
+
+    assert_equal ec.religious_background.persuasion, params[:religious_background][:persuasion]
+
+    assert_equal ec.address.street, params[:address][:street]
+    assert_equal ec.address.city, params[:address][:city]
+    assert_equal ec.address.zip, params[:address][:zip]
+
+    assert_equal ec.note.content, params[:note][:content]
+  end
+end

--- a/test/models/ethnic_church_builder_test.rb
+++ b/test/models/ethnic_church_builder_test.rb
@@ -1,54 +1,41 @@
 require 'test_helper'
 
 class EthnicChurchBuilderTest < ActiveSupport::TestCase
-  test 'EthnicChurchBuilder.instantiate' do
-    params = ActionController::Parameters.new({
-      ethnic_church: {
-        name: 'Foobar Korean Church',
-        phone: '123-456-7890',
-        website: 'https://example.com',
-        pastors_name: 'Peter Kim',
-        email: 'contact@example.com'
-      },
-      language: {
-        name: ['Korean', 'English']
-      },
-      country: {
-        name: 'Korea'
-      },
-      religious_background: {
-        persuasion: 'Protestant'
-      },
-      address: {
-        street: '1234 Foo St.',
-        city: 'Los Angeles',
-        zip: '90000'
-      },
-      note: {
-        content: 'Look! A note!'
-      }
-    })
+  test 'EthnicChurchBuilder.instantiate assigns associated objects' do
+    ethnic_church = ethnic_churches(:foobar)
+    languages = [languages(:chinese), languages(:english)]
+    country = countries(:china)
+    religious_background = religious_backgrounds(:protestant)
+    address = addresses(:los_angeles)
+    note = notes(:one)
 
-    ec = EthnicChurchBuilder.instantiate(params)
+    ec = EthnicChurchBuilder.instantiate(
+      ethnic_church: ethnic_church,
+      languages: languages,
+      country: country,
+      religious_background: religious_background,
+      address: address,
+      note: note
+    )
 
-    assert_equal ec.name, params[:ethnic_church][:name]
-    assert_equal ec.phone, params[:ethnic_church][:phone]
-    assert_equal ec.website, params[:ethnic_church][:website]
-    assert_equal ec.pastors_name, params[:ethnic_church][:pastors_name]
-    assert_equal ec.email, params[:ethnic_church][:email]
+    assert_equal ec.name, ethnic_church.name
+    assert_equal ec.phone, ethnic_church.phone
+    assert_equal ec.website, ethnic_church.website
+    assert_equal ec.pastors_name, ethnic_church.pastors_name
+    assert_equal ec.email, ethnic_church.email
 
-    params[:language][:name].each do |lang_name|
-      assert_includes ec.languages.map(&:name), lang_name
+    languages.each do |lang|
+      assert_includes ec.languages.map(&:name), lang.name
     end
 
-    assert_equal ec.country.name, params[:country][:name]
+    assert_equal ec.country.name, country.name
 
-    assert_equal ec.religious_background.persuasion, params[:religious_background][:persuasion]
+    assert_equal ec.religious_background.persuasion, religious_background.persuasion
 
-    assert_equal ec.address.street, params[:address][:street]
-    assert_equal ec.address.city, params[:address][:city]
-    assert_equal ec.address.zip, params[:address][:zip]
+    assert_equal ec.address.street, address.street
+    assert_equal ec.address.city, address.city
+    assert_equal ec.address.zip, address.zip
 
-    assert_equal ec.note.content, params[:note][:content]
+    assert_equal ec.note.content, note.content
   end
 end


### PR DESCRIPTION
Questions for reflection:
* Would using `accepts_nested_attributes_for` be more of a "rails way" of handling the association of all these objects?
* Would taking a more explicit approach to building up and associating objects be advantageous (rather than passing in everything as a hash)?
* Does `EthnicChurchBuilder` seem like the right place to handle white listing of the strong parameters? How else could this be handled?
* The large hash in `test/models/ethnic_church_builder_test.rb` feels a bit fragile to change? How might I adjust the test code to address this? Is this indicating a smell in the overall design itself?